### PR TITLE
Fixed parse error. removed extra <?php tag

### DIFF
--- a/index.php
+++ b/index.php
@@ -109,8 +109,6 @@ get_header(); ?>
 				<?php $i++; ?>
 				<!--------->
 
-			<?php
-
 
 
 		        <?php wp_reset_postdata(); ?>


### PR DESCRIPTION
Fix for theme load parse error. 

Error Log : `Parse error: syntax error, unexpected '<', expecting elseif (T_ELSEIF) or else (T_ELSE) or endif (T_ENDIF) in C:\xampp\htdocs\arnabwahid\wp-content\themes\sonnet\index.php on line 116`